### PR TITLE
JSON: Change escaping behavior

### DIFF
--- a/SymbolFixer.py
+++ b/SymbolFixer.py
@@ -77,8 +77,8 @@ def replace_non_ascii_with_space(text):
 
 
 def special_char_removal(text):
-    # Remove apostrophes, commas, and quotation marks
-    cleaned_text = text.replace("'", "").replace(",", "").replace('"', "")
+    # Remove apostrophes. Commas and quotation marks are not a concern.
+    cleaned_text = text.replace("'", "''") #.replace(",", "").replace('"', "")
 
     # Replace multiple spaces with a single space
     cleaned_text = re.sub(r'\s+', ' ', cleaned_text)

--- a/SymbolFixer.py
+++ b/SymbolFixer.py
@@ -77,7 +77,7 @@ def replace_non_ascii_with_space(text):
 
 
 def special_char_removal(text):
-    # Remove apostrophes. Commas and quotation marks are not a concern.
+    # Escape apostrophes. Commas and quotation marks are not a concern.
     cleaned_text = text.replace("'", "''") #.replace(",", "").replace('"', "")
 
     # Replace multiple spaces with a single space

--- a/TxTToJSON.py
+++ b/TxTToJSON.py
@@ -181,7 +181,7 @@ def compress_song_data(json_data):
 
     # Convert the dictionary to a compressed JSON string (no indent, no extra spaces)
     output_json = json.dumps(song_packs, separators=(',', ':'))
-    output_json = output_json.replace("'", "/")
+    output_json = output_json.replace("'", "''") # Escape ' for YAML entry
     #output_json = output_json.replace('"', "'")
 
     return f"'{output_json}'"  # Surround the entire output with quotes and strip spaces

--- a/TxTToJSON.py
+++ b/TxTToJSON.py
@@ -119,7 +119,7 @@ def compress_song_data(json_data):
 
     # Iterate through each pack in the JSON data
     for pack in json_data:
-        pack_name = pack["packName"]
+        pack_name = pack["packName"].replace("'","''")
 
         # Iterate through each song in the song list
         for song in pack["songs"]:
@@ -181,7 +181,7 @@ def compress_song_data(json_data):
 
     # Convert the dictionary to a compressed JSON string (no indent, no extra spaces)
     output_json = json.dumps(song_packs, separators=(',', ':'))
-    output_json = output_json.replace("'", "''") # Escape ' for YAML entry
+    #output_json = output_json.replace("'", "''") # Escape ' for YAML entry
     #output_json = output_json.replace('"', "'")
 
     return f"'{output_json}'"  # Surround the entire output with quotes and strip spaces

--- a/TxTToJSON.py
+++ b/TxTToJSON.py
@@ -181,13 +181,10 @@ def compress_song_data(json_data):
 
     # Convert the dictionary to a compressed JSON string (no indent, no extra spaces)
     output_json = json.dumps(song_packs, separators=(',', ':'))
+    output_json = output_json.replace("'", "/")
+    #output_json = output_json.replace('"', "'")
 
-    fix_json = output_json.replace("'", "/")
-
-    # Wrap in single quotes after
-    stringified_json = fix_json.replace('"', "'")
-
-    return f'"{stringified_json}"'  # Surround the entire output with quotes and strip spaces
+    return f"'{output_json}'"  # Surround the entire output with quotes and strip spaces
 
 
 


### PR DESCRIPTION
Preempting https://github.com/Cynichill/DivaAPworld/pull/13

With the move to FreeText and `json.loads` some requirements fell into place:
 - `json.loads` requires the keys be wrapped in `"`
 - to satisfy that, the FreeText string in the YAML must be wrapped in `'`

`'` were previously preprocessed to `/` but `''` should suffice. Currently it would misfire on these songs on the conversion back, if it weren't limited to pack names:

```
 242 1/6 -out of the gravity-
 916 Hello/How Are You
3440 POP/STARS
7295 1/6 -d2 mix-
```

*SymbolFixer.py*'s `cleaned_text = text.replace("'", "").replace(",", "").replace('"', "")` removes the `'` from song names but properly escaped to `''` should clear that up.

Note the pack name and `Wolves Aren't Scary`:
```
megamix_mod_data: '{"SP - Cabra''s Song Pack":[["Bitter Choco Decoration",687,{"H":7},{"EX":9},{"EXEX":10}],["Be My Guest",688,{"H":7},{"EX":8}],["THUNDERBOLT",689,{"EX":8.5}],["RRRRafflesia",691,{"H":6.5},{"EX":9}],["Just a Mount",692,{"EX":9.5}],["Mannequin",693,{"EX":9}],["Why do I",694,{"EX":8}],["NEPPUU",695,{"EX":9}],["Kara Kara Kara no Kara",3041,{"EX":10}],["City",3042,{"EX":8.5}],["Assassin Princess",3043,{"EX":8}],["The Iron Maiden and the Dreamy Princess",3044,{"EX":10}],["Dyed With Your Colors",3045,{"EX":8}],["+maleSign",3046,{"EX":10},{"EXEX":10}],["Rabbit Hole",3047,{"EX":10},{"EXEX":10}],["POMPADOUR",3048,{"H":5},{"EX":8}],["Mayday",3049,{"EX":9}],["Be Be Be Be!",3050,{"EX":9.5}],["Kimi no Koto ga Suki de Gomennasai",3051,{"EX":8.5}],["RoadRoLLeR Stampede",3052,{"EX":9.5}],["Last Dance",3053,{"H":6.5},{"EX":8.5}],["Agape Happy",3054,{"EX":9.5}],["Love Ka?",3055,{"EX":9}],["Harehare Ya",3056,{"H":4.5},{"EX":8.5}],["Beyond the Way",3057,{"EX":8.5}],["Wolves Aren''t Scary!",3058,{"H":6.5},{"EX":8.5}],["Ali Baba",3059,{"EX":9.5}],["The Lunacy of Duke Venomania",3060,{"EX":9}]]}'
```
and from the spoiler log:
```
MegaMixModData: {"SP - Cabra's Song Pack":[["Bitter Choco Decoration",687,{"H":7},{"EX":9},{"EXEX":10}],["Be My Guest",688,{"H":7},{"EX":8}],["THUNDERBOLT",689,{"EX":8.5}],["RRRRafflesia",691,{"H":6.5},{"EX":9}],["Just a Mount",692,{"EX":9.5}],["Mannequin",693,{"EX":9}],["Why do I",694,{"EX":8}],["NEPPUU",695,{"EX":9}],["Kara Kara Kara no Kara",3041,{"EX":10}],["City",3042,{"EX":8.5}],["Assassin Princess",3043,{"EX":8}],["The Iron Maiden and the Dreamy Princess",3044,{"EX":10}],["Dyed With Your Colors",3045,{"EX":8}],["+maleSign",3046,{"EX":10},{"EXEX":10}],["Rabbit Hole",3047,{"EX":10},{"EXEX":10}],["POMPADOUR",3048,{"H":5},{"EX":8}],["Mayday",3049,{"EX":9}],["Be Be Be Be!",3050,{"EX":9.5}],["Kimi no Koto ga Suki de Gomennasai",3051,{"EX":8.5}],["RoadRoLLeR Stampede",3052,{"EX":9.5}],["Last Dance",3053,{"H":6.5},{"EX":8.5}],["Agape Happy",3054,{"EX":9.5}],["Love Ka?",3055,{"EX":9}],["Harehare Ya",3056,{"H":4.5},{"EX":8.5}],["Beyond the Way",3057,{"EX":8.5}],["Wolves Aren't Scary!",3058,{"H":6.5},{"EX":8.5}],["Ali Baba",3059,{"EX":9.5}],["The Lunacy of Duke Venomania",3060,{"EX":9}]]}
```
~~This will require another PR to the world to properly handle the `'` being preserved in the item names.~~ Done in the initial JSON PR.