### PR TITLE
TxTToJSON: Compress difficulties

### DIFF
--- a/TxTToJSON.py
+++ b/TxTToJSON.py
@@ -159,7 +159,7 @@ def compress_song_data(json_data):
             song_name = song[0].strip('"')
 
             # Initialize a list for each song, starting with name and id
-            song_data = [song_name, int(song[1]), optimize_diffs(song[2:6])]
+            song_data = [song_name, int(song[1]), optimize_diffs(song[2:7])]
 
             # Add the song data to the song list
             song_list.append(song_data)

--- a/TxTToJSON.py
+++ b/TxTToJSON.py
@@ -159,19 +159,7 @@ def compress_song_data(json_data):
             song_name = song[0].strip('"')
 
             # Initialize a list for each song, starting with name and id
-            song_data = [song_name, int(song[1])]  # Store name and id as the first two elements
-
-            # Only add non-zero difficulty levels with corresponding letter keys
-            if song[2] != 0:  # E (Easy)
-                song_data.append({"E": song[2]})  # Append Easy difficulty
-            if song[3] != 0:  # N (Normal)
-                song_data.append({"N": song[3]})  # Append Normal difficulty
-            if song[4] != 0:  # H (Hard)
-                song_data.append({"H": song[4]})  # Append Hard difficulty
-            if song[5] != 0:  # EX (Extreme)
-                song_data.append({"EX": song[5]})  # Append Extreme difficulty
-            if song[6] != 0:  # EXEX (ExExtreme)
-                song_data.append({"EXEX": song[6]})  # Append ExExtreme difficulty
+            song_data = [song_name, int(song[1]), optimize_diffs(song[2:6])]
 
             # Add the song data to the song list
             song_list.append(song_data)
@@ -189,5 +177,14 @@ def compress_song_data(json_data):
 
     return f'"{stringified_json}"'  # Surround the entire output with quotes and strip spaces
 
+def optimize_diffs(diffs):
+    val = 0
 
+    for diff in diffs:
+        if isinstance(diff, int):
+            val = (val << 5) | diff
+        else:
+            pri = int(diff) | 1 << 4
+            val = (val << 5) | pri
 
+    return hex(val)[2:]

--- a/TxTToJSON.py
+++ b/TxTToJSON.py
@@ -181,10 +181,9 @@ def optimize_diffs(diffs):
     val = 0
 
     for diff in diffs:
-        if isinstance(diff, int):
-            val = (val << 5) | diff
-        else:
-            pri = int(diff) | 1 << 4
-            val = (val << 5) | pri
+        if not isinstance(diff, int):
+            diff = int(diff) | 1 << 4
+
+        val = (val << 5) | diff
 
     return val

--- a/TxTToJSON.py
+++ b/TxTToJSON.py
@@ -187,4 +187,4 @@ def optimize_diffs(diffs):
             pri = int(diff) | 1 << 4
             val = (val << 5) | pri
 
-    return hex(val)[2:]
+    return val


### PR DESCRIPTION
Turns out on average the integer value beats out hex and beyond because the latter needs to be wrapped in `"` throwing away the savings.
```
bytes ~1100 songs
50681 main
45889 [n,n,n,n,n]
43634 n,n,n,n,n
38092 b16
36850 b62 A-Za-z0-9
36801 b76 A-Za-z0-9!@#$%^&*()-=_+
36646 b87 A-Za-z0-9!@#$%^&*()-=_+[]{};:<>,.|
36273 b214 A-Za-z0-9!@#$%^&*()-=_+[]{};:<>,.| + basically the rest of Extended ASCII and ensure_ascii=False
36211 int
```
```
# Worst case (breaks rating standards)
53 {'E':9.5},{'N':9.5},{'H':9.5},{'EX':9.5},{'EXEX':9.5}
21 [9.5,9.5,9.5,9.5,9.5]
19 9.5,9.5,9.5,9.5,9.5
 8 27060025  (base 10)
 9 "19ce739" (base 16)
 7 "dKxvf"   (base 52 A-Za-z)
 7 "BzhiB"   (base 62 A-Za-z0-9)
 
# Typical case
21 {'EX':8},{'EXEX':9.5}
13 [0,0,0,8,9.5]
11 0,0,0,8,9.5
 3 281       (base 10)
 5 "119"     (base 16)

# Other typical case
18 {'H':6},{'EX':8.5}
13 [0,0,6,8.5,0]
11 0,0,6,8.5,0
 4 6912      (base 10)
 6 "1b00"    (base 16)

# Best case (breaks rating standards)
10 {'EXEX':1}
11 [0,0,0,0,1]
 9 0,0,0,0,1
 1 1         (base 10)
 3 "1"       (base 16)
```
A reversing function will be needed in the apworld. 